### PR TITLE
Moving MAINTAINERS from GitOps Working Group to OpenGitOps Project

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,8 @@
+The maintainers in alphabetical order are:
+
+Chris Patterson, GitHub <chrispat@github.com> (github: chrispat)
+Chris Sanders, Microsoft <chris.sanders@microsoft.com> (github: csand-msft)
+Dan Garfield, Codefresh <dan@codefresh.io> (github: todaywasawesome)
+Jesse Butler, Amazon Web Services <butlerjl@amazon.com> (github: jlbutler)
+Leonardo Murillo <leonardo@murillodigital.com> (github: murillodigital)
+Scott Rigby, Weaveworks <scott@weave.works> (github: scottrigby)


### PR DESCRIPTION
Relates to #2 

Signed-off-by: Leonardo Murillo <leonardo@murillodigital.com>