### PR TITLE
Update MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -3,6 +3,6 @@ The maintainers in alphabetical order are:
 Chris Patterson, GitHub <chrispat@github.com> (github: chrispat)
 Chris Sanders, Microsoft <chris.sanders@microsoft.com> (github: csand-msft)
 Dan Garfield, Codefresh <dan@codefresh.io> (github: todaywasawesome)
-Jesse Butler, Amazon Web Services <butlerjl@amazon.com> (github: jlbutler)
+Chris Short, Amazon Web Services <cbshort@amazon.com> (github: chris-short)
 Leonardo Murillo <leonardo@murillodigital.com> (github: murillodigital)
 Scott Rigby, Weaveworks <scott@weave.works> (github: scottrigby)


### PR DESCRIPTION
## To-do

Per Governance PR requires consensus by [existing maintainers](https://github.com/open-gitops/project/blob/main/MAINTAINERS) or if a vote is called a [supermajority vote](https://github.com/gitops-working-group/gitops-working-group/blob/main/GOVERNANCE.md#supermajority-decisions) (at least 4 of 6):

- [x] @chrispat
- [x] @csand-msft
- [x] @todaywasawesome
- [x] @jlbutler
- [x] @murillodigital
- [x] @scottrigby

## Original description by @chris-short

Hi all,

Jesse is changing roles internally here at AWS and will no longer be in the GitOps space as frequently as he has been. We've done a handoff and @scottrigby suggested we go ahead with a maintainers file change. To be clear, I've become AWS' point person on GitOps.

Signed-off-by cbshort@amazon.com