### PR TITLE
Remove inactive maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,9 +1,7 @@
 The maintainers in alphabetical order are:
 
-Chris Patterson, GitHub <chrispat@github.com> (github: chrispat)
-Chris Sanders, Microsoft <chris.sanders@microsoft.com> (github: csand-msft)
-Dan Garfield, Codefresh <dan@codefresh.io> (github: todaywasawesome)
 Chris Short, Amazon Web Services <cbshort@amazon.com> (github: chris-short)
+Christian Hernandez, <christian@chernand.io> (GitHub: christianh814)
+Dan Garfield, Codefresh <dan@codefresh.io> (github: todaywasawesome)
 Leonardo Murillo <leonardo@murillodigital.com> (github: murillodigital)
 Scott Rigby, Weaveworks <scott@weave.works> (github: scottrigby)
-Christian Hernandez, <christian@chernand.io> (GitHub: christianh814)


### PR DESCRIPTION
This PR removes inactive maintainers from the maintainers' file.

Context: #107 

Signed-off-by: Christian Hernandez <christian@codefresh.io>