### PR TITLE
Nominate Jaime Magiera for Maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -3,6 +3,7 @@ The maintainers in alphabetical order are:
 Chris Patterson, GitHub <chrispat@github.com> (github: chrispat)
 Chris Sanders, Microsoft <chris.sanders@microsoft.com> (github: csand-msft)
 Dan Garfield, Codefresh <dan@codefresh.io> (github: todaywasawesome)
+Jaime Magiera, <jaimelm@umich.edu> (github: JaimeMagiera)
 Chris Short, Amazon Web Services <cbshort@amazon.com> (github: chris-short)
 Leonardo Murillo <leonardo@murillodigital.com> (github: murillodigital)
 Scott Rigby, Weaveworks <scott@weave.works> (github: scottrigby)


### PR DESCRIPTION
Nominate @JaimeMagiera for Maintainer

Context #107 

Signed-off-by: Christian Hernandez <christian@codefresh.io>