### PR TITLE
Chris Patterson Stepping Down from Maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,5 @@
 The maintainers in alphabetical order are:
 
-Chris Patterson, GitHub <chrispat@github.com> (github: chrispat)
 Chris Sanders, Microsoft <chris.sanders@microsoft.com> (github: csand-msft)
 Chris Short, Amazon Web Services <cbshort@amazon.com> (github: chris-short)
 Christian Hernandez, <christian@chernand.io> (GitHub: christianh814)


### PR DESCRIPTION
Chris Patterson is one of the founding maintainers of the GitOps Working Group and the Open GitOps project, we are lucky to have had his vision and help moving this project forward. After speaking with Chris, his responsibilities at Github have pulled him into other areas and he hasn't had the time to contribute as much and has offered to step down. 

In another PR, I'd like to get together an emeritus status to thank Chris and other maintainers on the project. 

Signed-off-by: Dan Garfield <dan@codefresh.io>