### PR TITLE
Chris Sanders Stepping Down from Maintainers and add Emeritus section

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -3,5 +3,10 @@ The maintainers in alphabetical order are:
 Chris Short, Amazon Web Services <cbshort@amazon.com> (github: chris-short)
 Christian Hernandez, <christian@chernand.io> (GitHub: christianh814)
 Dan Garfield, Codefresh <dan@codefresh.io> (github: todaywasawesome)
+
+Emeritus:
+
+Chris Sanders, Microsoft <chris.sanders@microsoft.com> (github: csand-msft)
+Chris Patterson, GitHub <chrispat@github.com> (github: chrispat)
 Leonardo Murillo <leonardo@murillodigital.com> (github: murillodigital)
 Scott Rigby, Weaveworks <scott@weave.works> (github: scottrigby)

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,7 +1,6 @@
 The maintainers in alphabetical order are:
 
 Chris Patterson, GitHub <chrispat@github.com> (github: chrispat)
-Chris Sanders, Microsoft <chris.sanders@microsoft.com> (github: csand-msft)
 Chris Short, Amazon Web Services <cbshort@amazon.com> (github: chris-short)
 Christian Hernandez, <christian@chernand.io> (GitHub: christianh814)
 Dan Garfield, Codefresh <dan@codefresh.io> (github: todaywasawesome)


### PR DESCRIPTION
Chris Sanders is one of the founding maintainers of the GitOps Working Group and the Open GitOps project, he has not only contributed materially to our standards and project but also represented Open GitOps at conferences and other events. We are grateful for his work. Chris has shared with me that after a successful career he is planning to retire this month and will shift his focus to other activities. As such, he is planning to step down. 

In another PR, I'd like to get together an emeritus status to thank Chris and other maintainers on the project. 

Signed-off-by: Dan Garfield <dan@codefresh.io>