### PR TITLE
Move top level power to maintainers

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -93,7 +93,7 @@ The election process takes place on the CNCF SIG App Delivery mailing list <cncf
 
 Before each election, there will be a call for nominations on the mailing list.
 Nominations should be sent to the mailing list, and include a brief bio and personal statement describing the candidate's qualifications to serve in this capacity.
-Self-nominations are welcome. Only existing maintainers are eligible for nomination.
+Self-nominations are welcome. Only existing [Maintainers](#maintainers) are eligible for nomination.
 
 The GitOps WG employs "organization voting" to ensure no single organization can dominate the election process or project.
 Up to two individuals from organizations who are both active members of the CNCF and listed in the [interested parties](https://github.com/cncf/tag-app-delivery/blob/main/gitops-wg/interested-parties.md) may vote.
@@ -147,11 +147,11 @@ After they do so, they must be moved from the inactive section of the maintainer
 
 ### Simple Majority Decisions
 
-If a vote is called, the default is a Simple Majority Vote <https://en.wikipedia.org/wiki/Majority> - more than half of all active [Maintainers](#maintainers).
+If a vote is called, the default is a Simple Majority Vote - more than half of all active [Maintainers](#maintainers).
 
 ### Supermajority Decisions
 
-If a vote is called, the following decisions require a Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority> - two-thirds or more of all active [Maintainers](#maintainers).
+If a vote is called, the following decisions require a Supermajority Vote - two-thirds or more of all active [Maintainers](#maintainers).
 
 - Adding additional Maintainers.
 - Moving a Maintainer to [Inactive](#moving-a-maintainer-to-inactive)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -40,13 +40,16 @@ Current Maintainers are listed in a [MAINTAINERS](./MAINTAINERS) file at the roo
 
 Responsibilities:
 
+- Collectively care for the OpenGitOps project, as outlined in the [GitOps WG charter](https://github.com/cncf/tag-app-delivery/blob/main/gitops-wg/charter.md) Mission and Goals
 - Enable and promote GitOps Working Group community values
 - Engage with the wider GitOps community through appropriate [communication channels](https://github.com/cncf/tag-app-delivery/blob/main/gitops-wg/README.md#community)
 - Maintain involvement and open collaboration with working group members and committees
 - Review and approve pull requests
 - Ask for help when unsure and step down considerately when appropriate
 
-The GitHub `@gitops-working-group/maintainers` team will be kept up to date with current maintainers.
+Ultimately the Maintainers - after consulting with the community - drive the direction, values and governance of the overall project.
+
+The GitHub `@gitops-working-group/maintainers` team will be kept up to date with current Maintainers.
 
 ### Chairs
 
@@ -56,7 +59,6 @@ Current chairs are listed in a [CHAIRS.md](https://github.com/cncf/tag-app-deliv
 
 Responsibilities:
 
-- Primary role of Chairs is governance of the Working Group, who collectively care for the OpenGitOps project
 - Ensure the promotion of continued open involvement for the working group
 - Ensure that meetings and other activities are conducted and progress continues to be made against the project agenda, while also engaging other group members in leadership roles
 - Ensure discussion is extended asynchronously to be inclusive of members who cannot attend a specific meeting time
@@ -68,9 +70,6 @@ Responsibilities:
   Chairs are, however not responsible for performing all of the work - this is shared across the working group members and expected from those who have volunteered onto various workstreams.
 - When necessary, handle human and technical coordination across different working group workstreams
 - Handle Code of Conduct violations
-- Resolve escalated decisions when Maintainers can not reach consensus
-
-Ultimately the chairs - after consulting with the collective of Maintainers and their community - drive the direction, values and governance of the overall project.
 
 The GitHub `@gitops-working-group/chairs` team will be kept up to date with current chairs.
 
@@ -111,29 +110,31 @@ Representatives elected though this process will serve the remaining part of the
   This applies to all working communication by WG members (see [GitOps WG community info](https://github.com/cncf/tag-app-delivery/blob/main/gitops-wg/README.md#community)).
 - Most decisions begin by seeking Lazy Consensus <https://communitymgt.wikia.com/wiki/Lazy_consensus>.
 - If an objection is raised through the Lazy Consensus process, the group works together to seek an agreeable solution.
-- If Consensus can not be reached, but a decision must be made, the next step is try to attempt to agree that a vote should be called.
-  This is important, as it gives dissenting views a chance to request more information or raise further points.
-- If Maintainers can't agree on calling a vote, they may escalate to the Chairs.
+- If Consensus can not be reached, but a decision must be made, a vote among [Maintainers](#maintainers) will be called.
   This should only be done at this stage if:
-  1. An important deadline is threatened by continuing the Consensus process; or
-  2. A Decider feels there is unreasonable blocking of both reaching Consensus and agreeing to a vote.
+  1. A Maintainer feels an important deadline is threatened by continuing the Consensus process; or
+  2. A Maintainer feels there is unreasonable blocking of reaching Consensus.
       This should be rare, due to the social cost of discontinuing the Consensus process for this reason.
       Most decisions should wait for the above process to take its course.
-- If maintainers agree to a vote, the default is a Simple Majority.
-- However, there are cases that require stronger voting – Supermajority or Unanimity – specified below:
+- Calling a Maintainer vote and voting itself takes place via a GitHub issue.
+  For additional transparency these are also announced both on the the CNCF SIG App Delivery mailing list <cncf-sig-app-delivery@lists.cncf.io>,
+  as well as added to the agenda to be raised at the next weekly project meeting.
+  These steps for transparency are important, as they give dissenting views a chance to request more information or raise further points through the voting process even if they missed the initial discussion.
+- By default a vote requires a [Simple Majority](#simple-majority-decisions).
+- However, there are cases that require stronger voting – [Supermajority](#supermajority-decisions) – specified below.
 
 ### Simple Majority Decisions
 
-If a vote is called, the default is a Simple Majority Vote <https://en.wikipedia.org/wiki/Majority>.
+If a vote is called, the default is a Simple Majority Vote <https://en.wikipedia.org/wiki/Majority> by [Maintainers](#maintainers).
 
 ### Supermajority Decisions
 
-If a vote is called, the following decisions require a Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority>.
+If a vote is called, the following decisions require a Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority> by [Maintainers](#maintainers).
 
-- Maintainers: Adding additional maintainers.
-- Chairs: Enforcing a Code of Conduct violation by a community member.
-- Chairs: Licensing and intellectual property changes.
-- Chairs: Material changes to the Governance document.
+- Adding additional Maintainers.
+- Enforcing a Code of Conduct violation by a community member.
+- Licensing and intellectual property changes.
+- Material changes to the Governance document.
   - Note: editorial changes to governance may be made by lazy consensus, unless challenged.
     These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
     They do not change the intention or meaning of anything in this document.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -61,6 +61,7 @@ Project [Decision Making](#decision-making) must be able to procceed, while also
 In order to acheive this, inactive maintainer voting slots are not counted when tallying [Simple Majority](#simple-majority-decisions) or [Supermajority](#supermajority-decisions) decisions.
 
 Inactive Maintainers will be listed in an "inactive" section of the a [MAINTAINERS](./MAINTAINERS) file at the root of this git repository.
+See [Moving a Maintainer to Inactive](#moving-a-maintainer-to-inactive) for process.
 
 ### Chairs
 
@@ -113,6 +114,16 @@ In these cases, positions will be open both to previous holders and to any new n
 The standard nomination and [election](#elections) process will be carried out.
 Representatives elected though this process will serve the remaining part of the current term.
 
+### Moving a Maintainer to Inactive
+
+A Maintainer may be moved to [Inactive](#inactive-maintainers) status if they will be or have been away from their responsibilities for over 2 months,
+or if a [Decision](#decision-making) under vote is blocked by not receiving required responses due to inactivity by that Maintainer.
+
+Activity and inactivity is defined by one or more of the responsibilities listed for [Maintainers](#maintainers).
+
+Inactive maintainers return to their responsibilities when they are able, without the need for additional processes.
+After they do so, they must be moved from the inactive section of the maintainers file back to the active maintainers list in order for their votes to count in [decision making](#decision-making).
+
 ## Decision Making
 
 ### Decision Guidelines
@@ -143,6 +154,7 @@ If a vote is called, the default is a Simple Majority Vote <https://en.wikipedia
 If a vote is called, the following decisions require a Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority> - two-thirds or more of all active [Maintainers](#maintainers).
 
 - Adding additional Maintainers.
+- Moving a Maintainer to [Inactive](#moving-a-maintainer-to-inactive)
 - Enforcing a Code of Conduct violation by a community member.
 - Licensing and intellectual property changes.
 - Material changes to the Governance document.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -36,6 +36,7 @@ Current WG committees:
 
 Working Group and OpenGitOps project Maintainers are [Members](#all-members) who have shown significant and sustained contributions in the GitOps WG.
 The initial set of Maintainers were drawn from the organizations that proposed the creation of the working group.
+Maintainers must remain active in the project.
 Current Maintainers are listed in a [MAINTAINERS](./MAINTAINERS) file at the root of this git repository.
 
 Responsibilities:
@@ -45,11 +46,21 @@ Responsibilities:
 - Engage with the wider GitOps community through appropriate [communication channels](https://github.com/cncf/tag-app-delivery/blob/main/gitops-wg/README.md#community)
 - Maintain involvement and open collaboration with working group members and committees
 - Review and approve pull requests
-- Ask for help when unsure and step down considerately when appropriate
+- Participate in voting when needed
+- Ask for help when unsure
+- Notify fellow Maintainers before periods of inactivity when possible
+- Step down considerately when appropriate
 
 Ultimately the Maintainers - after consulting with the community - drive the direction, values and governance of the overall project.
 
 The GitHub `@gitops-working-group/maintainers` team will be kept up to date with current Maintainers.
+
+### Inactive Maintainers
+
+Project [Decision Making](#decision-making) must be able to procceed, while also respecting reasonable periods of inactivity by individual [Maintainers](#maintainers).
+In order to acheive this, inactive maintainer voting slots are not counted when tallying [Simple Majority](#simple-majority-decisions) or [Supermajority](#supermajority-decisions) decisions.
+
+Inactive Maintainers will be listed in an "inactive" section of the a [MAINTAINERS](./MAINTAINERS) file at the root of this git repository.
 
 ### Chairs
 
@@ -125,11 +136,11 @@ Representatives elected though this process will serve the remaining part of the
 
 ### Simple Majority Decisions
 
-If a vote is called, the default is a Simple Majority Vote <https://en.wikipedia.org/wiki/Majority> by [Maintainers](#maintainers).
+If a vote is called, the default is a Simple Majority Vote <https://en.wikipedia.org/wiki/Majority> - more than half of all active [Maintainers](#maintainers).
 
 ### Supermajority Decisions
 
-If a vote is called, the following decisions require a Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority> by [Maintainers](#maintainers).
+If a vote is called, the following decisions require a Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority> - two-thirds or more of all active [Maintainers](#maintainers).
 
 - Adding additional Maintainers.
 - Enforcing a Code of Conduct violation by a community member.


### PR DESCRIPTION
Discussed at multiple meetings. 

While I updated the final wording, @todaywasawesome discussed at length and agreed on the important details. Added Dan to Co-authored-by commit trailer for this reason.

Since this is a major governance change, I assigned all current maintainers (including maintainers who are chairs) as reviewers on this PR.