### PR TITLE
[WIP do not merge] fixes issue 140, adds hyphen to Apache-2.0 License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,3 @@
 # License
 
-Except as otherwise noted, the content of this repo is licensed under the [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/) ([local copy](LICENSES/CC-BY-4.0.txt)), and any code is licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html) ([local copy](LICENSES/APACHE-2.0.txt)).
+Except as otherwise noted, the content of this repo is licensed under the [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/) ([local copy](LICENSES/CC-BY-4.0.txt)), and any code is licensed under the [Apache-2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html) ([local copy](LICENSES/APACHE-2.0.txt)).


### PR DESCRIPTION
Adds a hyphen to "Apache 2.0" in LICENSE.md to make it "Apache-2.0" so that it should resolve a CLO Monitor report that open-gitops is missing a License https://clomonitor.io/projects/cncf/open-gitops#project_license

