### PR TITLE
Add Prateek to content/security team

### DIFF
--- a/TEAMS.md
+++ b/TEAMS.md
@@ -32,7 +32,7 @@ Please [reach out in any of the available ways](https://github.com/open-gitops/.
 |||||
 |--|--|--|--|
 | content/meme | proposed | [current discussion](https://github.com/open-gitops/project/discussions/102) | <ul><li>[scottrigby](https://github.com/scottrigby)</li></ul> |
-| content/security | proposed | [current discussion](https://github.com/open-gitops/project/issues/128) | <ul><li>[roberthstrand](https://github.com/roberthstrand)</li></ul> |
+| content/security | proposed | [current discussion](https://github.com/open-gitops/project/issues/128) | <ul><li>[roberthstrand](https://github.com/roberthstrand)</li><li>[@PrateekKumar1709](https://github.com/PrateekKumar1709)</li></ul> |
 | marketing/media-fact-checking | proposed | [current discussion](https://github.com/open-gitops/project/discussions/99) | <ul><li>[@makkes](https://github.com/makkes)</li><li>[@scottrigby](https://github.com/scottrigby)</li></ul> |
 
 ## Paused teams


### PR DESCRIPTION
Requesting to be added to the `content/security` team since I am currently working on this issue: https://github.com/open-gitops/website/issues/88

I have created a draft document here: https://docs.google.com/document/d/1DysKnybXOm0d094WSAXMMzN1iXOvJ3O07IrZZsdej0M/edit?usp=sharing 